### PR TITLE
Add support for holidays in Brazil and push method to Calendar class

### DIFF
--- a/lib/feriados.rb
+++ b/lib/feriados.rb
@@ -1,3 +1,4 @@
 require_relative './feriados/calendar'
 require_relative './feriados/rules'
 require_relative './feriados/argentina'
+require_relative './feriados/brazil'

--- a/lib/feriados/brazil.rb
+++ b/lib/feriados/brazil.rb
@@ -1,0 +1,23 @@
+module Feriados
+  module Brazil
+    include Feriados::Rules
+
+    def self.rules
+      [
+        DayOfMonth.new(1, 1),
+        DayOfMonth.new(21, 4),
+        DayOfMonth.new(1, 5),
+        DayOfMonth.new(4, 6),
+        DayOfMonth.new(7, 9),
+        DayOfMonth.new(12, 10),
+        DayOfMonth.new(2, 11),
+        DayOfMonth.new(15, 11),
+        DayOfMonth.new(25, 12),
+
+        HolyFriday,
+        CarnivalMonday,
+        CarnivalTuesday
+      ]
+    end
+  end
+end

--- a/lib/feriados/calendar.rb
+++ b/lib/feriados/calendar.rb
@@ -18,6 +18,10 @@ module Feriados
     def remove(rule)
       @rules.delete(rule)
     end
+
+    def push(rules)
+      @rules = rules
+    end
   end
 
   refine Date do


### PR DESCRIPTION
- **lib/feriados/brazil.rb**: Create a module configurated with national holidays from Brazil
- **lib/feriados.rb**: Add require for Brazilian holidays module
- **lib/feriados/calendar.rb**: Create a new instance method that allows push a entire array of holidays to Calendar's @rules attribute
